### PR TITLE
调整input字体大小

### DIFF
--- a/widget/input/input.less
+++ b/widget/input/input.less
@@ -77,11 +77,11 @@
 }
 
 :host.mini #input {
-  font-size: 0.8rem;
+  font-size: 0.6rem;
 }
 
 :host.small #input {
-  font-size: 0.6rem;
+  font-size: 0.7rem;
 }
 
 :host #input {
@@ -106,7 +106,7 @@
 .fa-times-circle {
   display: block;
   padding: 0;
-  margin: -0.5em 0 0 0;
+  margin: -0.48em 0 0 0;
 
   position: absolute;
   top: 50%;
@@ -115,28 +115,28 @@
 }
 
 :host.mini .fa-times-circle {
+  font-size: 0.6rem;
+  height: 0.6em;
+}
+
+:host.small .fa-times-circle {
+  font-size: 0.7rem;
+  height: 0.7em;
+}
+
+:host .fa-times-circle {
   font-size: 0.8rem;
   height: 0.8em;
 }
 
-:host.small .fa-times-circle {
+:host.large .fa-times-circle {
   font-size: 1rem;
   height: 1em;
 }
 
-:host .fa-times-circle {
+:host.big .fa-times-circle {
   font-size: 1.2rem;
   height: 1.2em;
-}
-
-:host.large .fa-times-circle {
-  font-size: 1.6rem;
-  height: 1.6em;
-}
-
-:host.big .fa-times-circle {
-  font-size: 2rem;
-  height: 2em;
 }
 
 :host[cancelable] #input {


### PR DESCRIPTION
原先 mini 字体居然比 samll 更大。。。
顺带修改了右侧清除按钮的大小，使他看起来更整齐。

调整后：
![image](https://cloud.githubusercontent.com/assets/7113508/15314835/cfd1daf2-1c46-11e6-810f-a0629d7d36dd.png)
